### PR TITLE
Local state

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,8 +6,6 @@
 
  :dependencies
  [[org.clojure/core.async "1.0.567"]
-  [com.rpl/specter "1.1.3"]
-  ;; [reagent "0.10.0"]
   [reagent "1.0.0-alpha1"]
   [reagent-utils "0.3.3"]
   [hiccup "1.0.5"]

--- a/src/main/bubble/bubble.cljs
+++ b/src/main/bubble/bubble.cljs
@@ -9,7 +9,6 @@
    :initial-state? true
    :done? false
    :edition? false
-   :show-button? false
    :cx 0
    :cy 0
    :rx 100 :ry 50

--- a/src/main/bubble/core.cljs
+++ b/src/main/bubble/core.cljs
@@ -10,33 +10,28 @@
    [reagent.dom :as rdom]
    ))
 
-(defn- draw-graph [rendering-style]
+(defn- which-renderer [rendering-style]
   (condp = rendering-style
     const/REDERING-STYLE-SOLID
-    [:g
-     {:id "graph"}
-     ;; Interactive part
-     (when (state-read/get-link-src)
-       [gui-solid/draw-building-link
-        (-> (state-read/get-link-src) state-read/get-bubble)
-        (state-read/get-mouse-position)])
-
-     ;; Static part
-     (let [couples_bubble
-           (map
-            (fn [link]
-              [(-> link :src state-read/get-bubble)
-               (-> link :dst state-read/get-bubble)])
-            (state-read/get-links))]
-       [gui-solid/draw-links couples_bubble])
-     [gui-solid/draw-bubbles (state-read/get-bubbles)]]
+    [gui-solid/draw-building-link
+     gui-solid/draw-links
+     gui-solid/draw-bubbles]
 
     const/REDERING-STYLE-ROUGH
+    [gui-rough/draw-building-link
+     gui-rough/draw-links
+     gui-rough/draw-bubbles]
+    )
+  )
+
+(defn- draw-graph []
+  (let [[draw-building-link draw-links draw-bubbles]
+        (which-renderer (state-read/get-rendering-style))]
     [:g
      {:id "graph"}
      ;; Interactive part
      (when (state-read/get-link-src)
-       [gui-rough/draw-building-link
+       [draw-building-link
         (-> (state-read/get-link-src) state-read/get-bubble)
         (state-read/get-mouse-position)])
 
@@ -47,9 +42,8 @@
               [(-> link :src state-read/get-bubble)
                (-> link :dst state-read/get-bubble)])
             (state-read/get-links))]
-       [gui-rough/draw-links couples_bubble])
-     [gui-rough/draw-bubbles (state-read/get-bubbles)]]
-    ))
+       [draw-links couples_bubble])
+     [draw-bubbles (state-read/get-bubbles)]]))
 
 (defn svg-canvas []
   (reagent/create-class
@@ -92,4 +86,4 @@
          [:feComposite {:in "SourceGraphic" :operator "xor"}]
          ]]
 
-       [draw-graph (state-read/get-rendering-style)]])}))
+       [draw-graph]])}))

--- a/src/main/bubble/core.cljs
+++ b/src/main/bubble/core.cljs
@@ -53,17 +53,14 @@
 
 (defn svg-canvas []
   (reagent/create-class
-   {
-    :display-name "svg-canvas"
+   {:display-name "svg-canvas"
 
     :component-did-mount
-    (let [dom-node (reagent/atom nil)]
-      (fn [this]
-        (reset! dom-node (rdom/dom-node this))
-        (let [svg-bbox-client (.getBoundingClientRect @dom-node)
-              svg-origin-x (.-left svg-bbox-client)
-              svg-origin-y (.-top svg-bbox-client)]
-          (coord/init-svg-origin! svg-origin-x svg-origin-y))))
+    (fn [this]
+      (let [svg-bbox-client (.getBoundingClientRect (rdom/dom-node this))
+            svg-origin-x (.-left svg-bbox-client)
+            svg-origin-y (.-top svg-bbox-client)]
+        (coord/init-svg-origin! svg-origin-x svg-origin-y)))
 
     :reagent-render
     (fn []
@@ -80,7 +77,10 @@
          }
 
         :on-context-menu
-        (event/prevent-context-menu)
+        (event/prevent-default)
+
+        :on-drag-start
+        (event/prevent-default)
         }
 
        ;; This filter is used in rough display mode: background of text node

--- a/src/main/bubble/core.cljs
+++ b/src/main/bubble/core.cljs
@@ -13,9 +13,12 @@
 (defn- which-renderer [rendering-style]
   (condp = rendering-style
     const/REDERING-STYLE-SOLID
-    [gui-solid/draw-building-link
+    #_[gui-solid/draw-building-link
      gui-solid/draw-links
      gui-solid/draw-bubbles]
+    [gui-rough/draw-building-link
+     gui-rough/draw-links
+     gui-rough/draw-bubbles]
 
     const/REDERING-STYLE-ROUGH
     [gui-rough/draw-building-link

--- a/src/main/bubble/core.cljs
+++ b/src/main/bubble/core.cljs
@@ -92,5 +92,4 @@
          [:feComposite {:in "SourceGraphic" :operator "xor"}]
          ]]
 
-       [draw-graph (state-read/get-rendering-style)]
-       ])}))
+       [draw-graph (state-read/get-rendering-style)]])}))

--- a/src/main/bubble/core.cljs
+++ b/src/main/bubble/core.cljs
@@ -13,10 +13,10 @@
 (defn- which-renderer [rendering-style]
   (condp = rendering-style
     const/REDERING-STYLE-SOLID
-    #_[gui-solid/draw-building-link
+    [gui-solid/draw-building-link
      gui-solid/draw-links
      gui-solid/draw-bubbles]
-    [gui-rough/draw-building-link
+    #_[gui-rough/draw-building-link
      gui-rough/draw-links
      gui-rough/draw-bubbles]
 

--- a/src/main/bubble/event.cljs
+++ b/src/main/bubble/event.cljs
@@ -97,7 +97,7 @@
 
 (window-keydown-evt-fn) ;; auto-execution
 
-(defn window-keystroke-evt [evt]
+(defn window-keypress-evt [evt]
   (let [t-key-code 116]
     (condp = (.-keyCode evt)
       t-key-code
@@ -106,11 +106,11 @@
       nil
       )))
 
-(defn window-keystroke-evt-fn []
-  (events/listen js/window EventType.KEYPRESS window-keystroke-evt)
+(defn window-keypress-evt-fn []
+  (events/listen js/window EventType.KEYPRESS window-keypress-evt)
   )
 
-(window-keystroke-evt-fn) ;; auto-execution
+(window-keypress-evt-fn) ;; auto-execution
 
 (defn prevent-default
   ([] (prevent-default (fn [])))

--- a/src/main/bubble/event.cljs
+++ b/src/main/bubble/event.cljs
@@ -112,8 +112,8 @@
 
 (window-keystroke-evt-fn) ;; auto-execution
 
-(defn prevent-context-menu
-  ([] (prevent-context-menu (fn [])))
+(defn prevent-default
+  ([] (prevent-default (fn [])))
   ([func]
    (fn [evt]
      (.preventDefault evt)

--- a/src/main/bubble/event.cljs
+++ b/src/main/bubble/event.cljs
@@ -57,14 +57,6 @@
     (let [[id] args]
       (state-write/disable-edition! id))
 
-    :enable-show-button
-    (let [[id] args]
-      (state-write/enable-show-button! id))
-
-    :disable-show-button
-    (let [[id] args]
-      (state-write/disable-show-button! id))
-
     :save-text
     (let [[id text] args]
       (state-write/save-text-bubble! id text))

--- a/src/main/bubble/event_factory.cljs
+++ b/src/main/bubble/event_factory.cljs
@@ -3,7 +3,6 @@
    [bubble.build-link :as build-link]
    [bubble.constant :as const]
    [bubble.drag :as drag]
-   [bubble.state-read :as state-read]
    [bubble.event :as event]
    [cljs.core.async :refer [put!]]
    ))

--- a/src/main/bubble/event_factory.cljs
+++ b/src/main/bubble/event_factory.cljs
@@ -44,18 +44,6 @@
        :on-click
        #(put! event/event-queue [:toggle-done-status id])})
 
-    :bubble
-    (let [[bubble] args
-          {:keys [id]} bubble]
-      {:pointer-events "bounding-box"
-       :on-mouse-over
-       (if (state-read/get-link-src)
-         #(put! event/event-queue [:disable-show-button id])
-         #(put! event/event-queue [:enable-show-button id])
-         )
-       :on-mouse-leave
-       #(put! event/event-queue [:disable-show-button id])})
-
     :common-text-ellipse
     (let [[bubble] args
           {:keys [id type]} bubble]

--- a/src/main/bubble/event_factory.cljs
+++ b/src/main/bubble/event_factory.cljs
@@ -67,7 +67,7 @@
 
        :on-context-menu
        (when (not= type const/ROOT-BUBBLE-TYPE)
-         (event/prevent-context-menu
+         (event/prevent-default
           #(put! event/event-queue [:delete-bubble id])))
 
        :on-click

--- a/src/main/bubble/gui_rough.cljs
+++ b/src/main/bubble/gui_rough.cljs
@@ -256,17 +256,18 @@
                (map-indexed
                 (fn [idx text] [idx text])
                 (-> bubble :text string/split-lines))]
-           (let [tspan-id (str id idx)]
+           (let [tspan-id (str id idx)
+                 dy-value (if (= idx 0) 0 "1.2em")]
              ^{:key tspan-id}
              [:<>
               [:tspan
                (merge tspan-style
-                      {:x cx :dy (if (= idx 0) 0 "1.2em")
+                      {:x cx :dy dy-value
                        :filter "url(#bg-text)"})
                tspan-text]
               [:tspan
                (merge tspan-style
-                      {:x cx :dy (if (= idx 0) 0 "1.2em")})
+                      {:x cx :dy dy-value})
                tspan-text]]))]))}))
 
 (defn- draw-ellipse

--- a/src/main/bubble/gui_rough.cljs
+++ b/src/main/bubble/gui_rough.cljs
@@ -299,7 +299,7 @@
      [:<>
       [draw-ellipse bubble
        (+ const/ROOT-BUBBLE-OFFSET rx)
-       (+ const/ROOT-BUBBLE-OFFSET  ry)
+       (+ const/ROOT-BUBBLE-OFFSET ry)
        (event-factory/event-property-factory
         :ellipse
         bubble
@@ -321,8 +321,8 @@
 (defn draw-bubbles [bubbles]
   [:<>
    (doall
-    (for [bubble bubbles]
-      ^{:key (:id bubble)}
+    (for [[bubble-id bubble] bubbles]
+      ^{:key bubble-id}
       [draw-bubble bubble
        (event-factory/event-property-factory :bubble bubble)]
       )

--- a/src/main/bubble/gui_solid.cljs
+++ b/src/main/bubble/gui_solid.cljs
@@ -283,8 +283,8 @@
 (defn draw-bubbles [bubbles]
   [:<>
    (doall
-    (for [bubble bubbles]
-      ^{:key (:id bubble)}
+    (for [[bubble-id bubble] bubbles]
+      ^{:key bubble-id}
       [draw-bubble bubble
        (event-factory/event-property-factory :bubble bubble)]
       )

--- a/src/main/bubble/gui_solid.cljs
+++ b/src/main/bubble/gui_solid.cljs
@@ -3,6 +3,7 @@
    [bubble.constant :as const]
    [bubble.event-factory :as event-factory]
    [bubble.gui-common :as gui-common]
+   [bubble.state-read :as state-read]
    [clojure.string :as string]
    [reagent.core :as reagent]
    [reagent.dom :as rdom]
@@ -70,7 +71,7 @@
          [draw-link src-b dst-b]]))]))
 
 (defn- draw-pencil-button
-  [{:keys [cx cy show-button?]} ry
+  [{:keys [cx cy]} ry show-button?
    event-properties]
   (let [semi-length 15
         min-bound (- 0 semi-length)
@@ -102,7 +103,7 @@
   )
 
 (defn- draw-link-button
-  [{:keys [cx cy show-button?]} ry
+  [{:keys [cx cy]} ry show-button?
    event-properties]
   (let [x-offset (+ cx 60)
         y-offset (- cy (+ ry 5))
@@ -122,7 +123,7 @@
      ]))
 
 (defn- draw-delete-button
-  [{:keys [cx cy show-button?]} ry
+  [{:keys [cx cy]} ry show-button?
    event-properties]
   (let [semi-length 15
         min-bound (- 0 semi-length)
@@ -142,7 +143,7 @@
   )
 
 (defn- draw-validation-button
-  [{:keys [cx cy show-button?]} ry
+  [{:keys [cx cy]} ry show-button?
    event-properties]
   (let [length 30
         x-offset cx
@@ -161,26 +162,26 @@
      ])
   )
 
-(defn- add-button [{:keys [type ry] :as bubble}]
+(defn- add-button [{:keys [type ry] :as bubble} show-button?]
   (condp = type
     const/ROOT-BUBBLE-TYPE
     [:<>
-     [draw-validation-button bubble (+ 10 ry)
+     [draw-validation-button bubble (+ 10 ry) show-button?
       (event-factory/event-property-factory :validation-button bubble)]
-     [draw-pencil-button bubble (+ 10 ry)
+     [draw-pencil-button bubble (+ 10 ry) show-button?
       (event-factory/event-property-factory :pencil-button bubble)]
-     [draw-link-button bubble (+ 10 ry)
+     [draw-link-button bubble (+ 10 ry) show-button?
       (event-factory/event-property-factory :link-button bubble)]]
 
     const/BUBBLE-TYPE
     [:<>
-     [draw-validation-button bubble ry
+     [draw-validation-button bubble ry show-button?
       (event-factory/event-property-factory :validation-button bubble)]
-     [draw-delete-button bubble ry
+     [draw-delete-button bubble ry show-button?
       (event-factory/event-property-factory :delete-button bubble)]
-     [draw-pencil-button bubble ry
+     [draw-pencil-button bubble ry show-button?
       (event-factory/event-property-factory :pencil-button bubble)]
-     [draw-link-button bubble ry
+     [draw-link-button bubble ry show-button?
       (event-factory/event-property-factory :link-button bubble)]]
 
     nil))
@@ -196,8 +197,7 @@
   [bubble
    event-property]
   (reagent/create-class
-   {
-    :display-name "bubble-text"
+   {:display-name "bubble-text"
 
     :component-did-mount
     (fn [this]
@@ -250,42 +250,49 @@
            })])
 
 (defn- draw-bubble
-  [{:keys [id type rx ry edition?] :as bubble}
-   event-property]
-  ^{:key (str id "-group")}
-  [:g
-   (merge event-property
-          {:class "bubble"})
+  [{:keys [id type rx ry edition?] :as bubble}]
+  (let [show-button? (reagent/atom false)]
+    (fn [{:keys [id type rx ry edition?] :as bubble}]
+      [:g
+       {:class "bubble"
+        :key (str id "-group")
+        :pointer-events "bounding-box"
+        :on-mouse-over
+        (fn []
+          (if (state-read/get-link-src)
+            (reset! show-button? false)
+            (reset! show-button? true)))
+        :on-mouse-leave
+        #(reset! show-button? false)}
 
-   (condp = type
-     const/ROOT-BUBBLE-TYPE
-     [:<>
-      [draw-ellipse bubble (+ 10 rx) (+ 10 ry)
-       (event-factory/event-property-factory :ellipse bubble (+ 10 ry))]
-      [draw-ellipse bubble rx ry
-       (event-factory/event-property-factory :ellipse bubble ry)]]
+       (condp = type
+         const/ROOT-BUBBLE-TYPE
+         [:<>
+          [draw-ellipse bubble (+ 10 rx) (+ 10 ry)
+           (event-factory/event-property-factory :ellipse bubble (+ 10 ry))]
+          [draw-ellipse bubble rx ry
+           (event-factory/event-property-factory :ellipse bubble ry)]]
 
-     const/BUBBLE-TYPE
-     [draw-ellipse bubble rx ry
-      (event-factory/event-property-factory :ellipse bubble ry)]
+         const/BUBBLE-TYPE
+         [draw-ellipse bubble rx ry
+          (event-factory/event-property-factory :ellipse bubble ry)]
 
-     nil)
+         nil)
 
-   (if edition?
-     [gui-common/bubble-input bubble]
-     [:<>
-      [bubble-text bubble
-       (event-factory/event-property-factory :text bubble)]
-      [add-button bubble]]
-     )
-   ])
+       (if edition?
+         [gui-common/bubble-input bubble]
+         [:<>
+          [bubble-text bubble
+           (event-factory/event-property-factory :text bubble)]
+          [add-button bubble @show-button?]]
+         )
+       ])))
 
 (defn draw-bubbles [bubbles]
   [:<>
    (doall
     (for [[bubble-id bubble] bubbles]
       ^{:key bubble-id}
-      [draw-bubble bubble
-       (event-factory/event-property-factory :bubble bubble)]
+      [draw-bubble bubble]
       )
     )])

--- a/src/main/bubble/state.cljs
+++ b/src/main/bubble/state.cljs
@@ -1,18 +1,16 @@
 (ns bubble.state
   (:require
    [bubble.bubble :as bubble]
-   [bubble.constant :refer [REDERING-STYLE-SOLID]]
+   [bubble.constant :refer [REDERING-STYLE-SOLID ROOT-BUBBLE-ID]]
    [reagent.core :rename {atom ratom}]
    ))
 
 (defn- init-appstate []
-  {
-   :bubbles [bubble/root-bubble]
+  {:bubbles {ROOT-BUBBLE-ID bubble/root-bubble}
    :links []
    :link-src nil
    :mouse-position nil
-   :rendering-style REDERING-STYLE-SOLID
-   })
+   :rendering-style REDERING-STYLE-SOLID})
 
 (defonce appstate
   (ratom (init-appstate)))

--- a/src/main/bubble/state_read.cljs
+++ b/src/main/bubble/state_read.cljs
@@ -1,7 +1,6 @@
 (ns bubble.state-read
   (:require
    [bubble.state :refer [appstate]]
-   [com.rpl.specter :as sp]
    ))
 
 ;; Read application state
@@ -10,7 +9,7 @@
 (defn get-bubble
   ([id] (get-bubble @appstate id))
   ([appstate id]
-   (first (filter #(= (:id %) id) (:bubbles appstate)))))
+   (-> appstate :bubbles (#(get % id)))))
 
 (defn get-bubbles
   ([] (get-bubbles @appstate))
@@ -20,9 +19,7 @@
 (defn get-list-id
   ([] (get-list-id @appstate))
   ([appstate]
-   (->> (get-bubbles appstate)
-        (sp/transform [sp/ALL] :id)
-        )))
+   (-> appstate :bubbles keys)))
 
 (defn bubble-id-exist [appstate id]
   (let [idx (get-list-id appstate)]
@@ -30,7 +27,6 @@
 ;; END: bubble part
 
 ;; START: link part
-
 (defn get-link-src []
   (:link-src @appstate))
 

--- a/src/main/bubble/state_write.cljs
+++ b/src/main/bubble/state_write.cljs
@@ -203,18 +203,6 @@
 ;; END: Edition
 
 
-;; START: Show button
-(defn- enable-show-button [appstate bubble-id]
-  (update-bubble appstate bubble-id {:show-button? true}))
-
-(defn- disable-show-button [appstate bubble-id]
-  (update-bubble appstate bubble-id {:show-button? false}))
-
-(macro/BANG enable-show-button)
-(macro/BANG disable-show-button)
-;; END: Show button
-
-
 ;; START: Toggle done
 (defn- toggle-done-status [appstate bubble-id]
   (let [bubble (state-read/get-bubble appstate bubble-id)

--- a/src/test/bubble/state_write_test.cljs
+++ b/src/test/bubble/state_write_test.cljs
@@ -1,7 +1,7 @@
 (ns bubble.state-write-test
   (:require
    [bubble.bubble :as b]
-   [bubble.constant :refer (ROOT-BUBBLE-ID)]
+   [bubble.constant :refer [ROOT-BUBBLE-ID]]
    [bubble.state :as sd]
    [bubble.state-read :as sr]
    [bubble.state-write :as sw]
@@ -12,33 +12,33 @@
   (is
    (=
     (-> (#'sd/init-appstate) :bubbles)
-    [b/root-bubble])
+    {ROOT-BUBBLE-ID b/root-bubble})
    "Is the appstate initialised with the root bubble"))
 
 (deftest add-bubble_basic
-  (is
-   (=
-    (-> (#'sd/init-appstate)
-        (#'sw/add-bubble (b/create-bubble "fake-bubble" 0 0))
-        (sr/get-bubble "fake-bubble")
-        :id)
-    "fake-bubble"
-    )
-   "Is a new bubble 'fake-bubble' exist in the appstate")
+  (let [fake-bubble (b/create-bubble "fake-bubble" 0 0)]
+    (is
+     (=
+      (-> (#'sd/init-appstate)
+          (#'sw/add-bubble "fake-bubble" fake-bubble)
+          (sr/get-bubble "fake-bubble"))
+      fake-bubble
+      )
+     "Is a new bubble 'fake-bubble' exist in the appstate"))
   )
 
 (deftest delete-bubble_basic
   (let [new-appstate
         (-> (#'sd/init-appstate)
-            (#'sw/add-bubble (b/create-bubble "fake-bubble" 0 0))
+            (#'sw/add-bubble "fake-bubble" (b/create-bubble "fake-bubble" 0 0))
             (#'sw/delete-bubble "fake-bubble"))]
     (is
-     (vector? (-> new-appstate :bubbles))
-     "The 'bubbles' collection remain a vector")
+     (map? (-> new-appstate :bubbles))
+     "The 'bubbles' collection remain a map")
     (is
      (=
       (-> new-appstate :bubbles)
-      [b/root-bubble])
+      {ROOT-BUBBLE-ID b/root-bubble} #_[b/root-bubble])
      "The only remaining bubble is the root bubble")
     )
   )
@@ -55,7 +55,7 @@
 
 (def appstate-2-bubble
   (-> (#'sd/init-appstate)
-      (#'sw/add-bubble (b/create-bubble "bubble-1" 0 0)))
+      (#'sw/add-bubble "bubble-1" (b/create-bubble "bubble-1" 0 0)))
   )
 
 (deftest add-link_basic

--- a/src/test/bubble/state_write_test.cljs
+++ b/src/test/bubble/state_write_test.cljs
@@ -121,24 +121,6 @@
     (is
      (true? (-> (sr/get-bubble new-appstate "bubble-1") :edition?)))))
 
-(deftest enable-show-button_basic
-  (let [new-appstate (#'sw/enable-show-button appstate-2-bubble ROOT-BUBBLE-ID)]
-    (is
-     (true? (-> (sr/get-bubble new-appstate ROOT-BUBBLE-ID) :show-button?)))
-    (is
-     (false? (-> (sr/get-bubble new-appstate "bubble-1") :show-button?)))))
-
-(deftest disable-show-button_basic
-  (let [new-appstate
-        (-> appstate-2-bubble
-            (#'sw/enable-show-button ROOT-BUBBLE-ID)
-            (#'sw/enable-show-button "bubble-1")
-            (#'sw/disable-show-button ROOT-BUBBLE-ID))]
-    (is
-     (false? (-> (sr/get-bubble new-appstate ROOT-BUBBLE-ID) :show-button?)))
-    (is
-     (true? (-> (sr/get-bubble new-appstate "bubble-1") :show-button?)))))
-
 (deftest toggle-done-status_basic
   (let [new-appstate
         (-> appstate-2-bubble


### PR DESCRIPTION
Remove the `show-button?` field from the bubble map, so from the app-state.
Reduce the number of re-rendering:
 - don't re-render all the graph during a drag
 - don't re-render when the mouse pointer enter or exit a bubble

During a drag, only the dragged bubble is re-render as well as the adjacent links.